### PR TITLE
Truncate file names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,7 +145,10 @@ async fn exec_cmd(client: &Client, session: &Session, cmd: Command) -> Result<()
                         let target_file = cfg.path.join(format!(
                             "{}-{}.eml",
                             mail.date.format("%Y-%m-%d-%Hh%Mm%Ss"),
-                            escape_file_string(&mail.subject),
+                            escape_file_string(&mail.subject)
+                                .chars()
+                                .take(64)
+                                .collect::<String>(),
                         ));
 
                         if tokio::fs::try_exists(&target_file)


### PR DESCRIPTION
Truncate file names to avoid "File name too long" errors if email has long subject