### PR TITLE
feat: Increase buffer size

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -12,6 +12,7 @@ pub(crate) fn decompress_value(v: &[u8]) -> Result<Vec<u8>> {
             }
         }
     }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -1,5 +1,15 @@
 use anyhow::{Context, Result};
 
 pub(crate) fn decompress_value(v: &[u8]) -> Result<Vec<u8>> {
-    lz4_flex::block::decompress(v, v.len() * 6).context("decompression")
+    match lz4_flex::block::decompress(v, v.len() * 6) {
+        Ok(result) => Ok(result),
+        Err(e) => {
+            // If it failed and the error suggests buffer too small, retry with 10x
+            if e.to_string().contains("too small") {
+                lz4_flex::block::decompress(v, v.len() * 10).context("decompression retry")
+            } else {
+                Err(e).context("decompression")
+            }
+        }
+    }
 }


### PR DESCRIPTION
## what

Increase buffer size if the buffer is too small to decompress.

## why

Fix errors like the following:

```
    Finished `release` profile [optimized] target(s) in 0.11s
     Running `target/release/tatutanatata -v download --folder=Inbox --path=./output`
2024-12-04T15:15:24.125844Z  INFO tatutanatata: already exists folder_id="XXXXXX" mail_id="XXXXXX"
2024-12-04T15:15:24.125942Z  INFO tatutanatata: already exists folder_id="XXXXXX" mail_id="XXXXXX"
2024-12-04T15:15:24.125960Z  INFO tatutanatata: download folder_id="XXXXXX" mail_id="XXXXXX"
2024-12-04T15:15:24.126099Z  INFO tatutanatata: already exists folder_id="XXXXXX" mail_id="XXXXXX"
2024-12-04T15:15:24.126117Z  INFO tatutanatata: download folder_id="XXXXXX" mail_id="XXXXXX"
2024-12-04T15:15:24.126229Z  INFO tatutanatata: download folder_id="XXXXXX" mail_id="XXXXXX"
2024-12-04T15:15:24.126279Z  INFO tatutanatata: download folder_id="XXXXXX" mail_id="XXXXXX"
2024-12-04T15:15:24.126306Z  INFO tatutanatata: download folder_id="XXXXXX" mail_id="XXXXXX"
Error: execute command

Caused by:
    0: download mail (`https://app.tuta.com/mail/XXXXXX/XXXXX----2`)
    1: decode body
    2: decompress
    3: decompression
    4: provided output is too small for the decompressed data, actual 20310, expected 20315
```